### PR TITLE
ToCamelCase helper that matches JSON.NET convention

### DIFF
--- a/src/NetTypeS/NetTypeS.Example/Program.cs
+++ b/src/NetTypeS/NetTypeS.Example/Program.cs
@@ -10,6 +10,7 @@ using NetTypeS.Example.Classes;
 using NetTypeS.Example.Enums;
 using NetTypeS.Example.Generics;
 using NetTypeS.Example.Interfaces;
+using NetTypeS.Utils;
 
 namespace NetTypeS.Example
 {
@@ -108,8 +109,7 @@ namespace NetTypeS.Example
 						.ForEnums(et =>
 							Element.New()
 								.AddText("var ")
-								.AddText(et.Name.Remove(1).ToLowerInvariant())
-								.AddText(et.Name.Substring(1))
+								.AddText(StringUtils.ToCamelCase(et.Name))
 								.AddText("Names = ")
 								.AddBlock(et.Values.Select((ev, i) =>
 									Element.New()

--- a/src/NetTypeS/NetTypeS/GeneratorSettings.cs
+++ b/src/NetTypeS/NetTypeS/GeneratorSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using NetTypeS.Delegates;
 using NetTypeS.Interfaces;
+using NetTypeS.Utils;
 
 namespace NetTypeS
 {
@@ -24,7 +25,7 @@ namespace NetTypeS
 				name => name;
 
 			public static CustomNameFormatter PropertyNameFormatter =
-				name => name.Remove(1).ToLowerInvariant() + name.Substring(1);
+				name => StringUtils.ToCamelCase(name);
 
 			public static CustomPropertyFilter PropertyFilter =
 				prop => !typeof (Delegate).IsAssignableFrom(prop.Type); //Exclude properties with delegates

--- a/src/NetTypeS/NetTypeS/Utils/StringUtils.cs
+++ b/src/NetTypeS/NetTypeS/Utils/StringUtils.cs
@@ -2,11 +2,33 @@
 
 namespace NetTypeS.Utils
 {
-	internal static class StringUtils
+	public static class StringUtils
 	{
 		public static string[] GetLines(this string str)
 		{
 			return str.Split('\n').Select(l => l.TrimEnd('\r')).ToArray();
 		}
+
+        public static string ToCamelCase(string s)
+        {
+            if (string.IsNullOrEmpty(s))
+                return s;
+
+            if (!char.IsUpper(s[0]))
+                return s;
+
+            char[] chars = s.ToCharArray();
+
+            for (int i = 0; i < chars.Length; i++)
+            {
+                bool hasNext = (i + 1 < chars.Length);
+                if (i > 0 && hasNext && !char.IsUpper(chars[i + 1]))
+                    break;
+
+                chars[i] = char.ToLowerInvariant(chars[i]);
+            }
+
+            return new string(chars);
+        }
 	}
 }


### PR DESCRIPTION
Camel-casing identifiers with several capitals at the start is corrected: "ABCTest" -> "abcTest", not "aBCTest".

ToCamelCase helper is taken as is from JSON.NET sources, so the new approach should work exactly as CamelCasePropertyNamesContractResolver from JSON.NET do.
